### PR TITLE
Added arrow-icon rotation on collapse

### DIFF
--- a/app/assets/javascripts/overview.js
+++ b/app/assets/javascripts/overview.js
@@ -1,0 +1,4 @@
+$(window).on('load', () => {
+    $('.stugen-container.collapse').on('show.bs.collapse', (event) => event.target.parentNode.classList.add('open'))
+    $('.stugen-container.collapse').on('hide.bs.collapse', (event) => event.target.parentNode.classList.remove('open'))
+})

--- a/app/assets/stylesheets/overview.scss
+++ b/app/assets/stylesheets/overview.scss
@@ -1,0 +1,8 @@
+.faculty {
+    &.open h3 > i {
+        transform: rotate(90deg);
+    }
+    h3 > i {
+        transition: transform 0.5s 0s;
+    }
+}


### PR DESCRIPTION
The arrow-icon turns now by 90 degree on opening or closing of faculty-boxes. It works even with the global collapse-state toggle.