### PR TITLE
Set HTML language attribute to actual locale

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html(lang="en")
+%html{:lang => I18n.locale}
   %head
     %meta(charset="utf-8")
     %meta(http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1")

--- a/app/views/layouts/overview.html.haml
+++ b/app/views/layouts/overview.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html(lang="en")
+%html{:lang => I18n.locale}
   %head
     %meta(charset="utf-8")
     %meta(http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1")


### PR DESCRIPTION
This fix helps screen-readers and translation tools to work with the actual language of the texts on the page by setting the html-lang attribute to the proper value.